### PR TITLE
Fixed default root path (issue #6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 coverage.xml
 
 bin/
-
+goblog

--- a/src/install/config.go
+++ b/src/install/config.go
@@ -34,7 +34,7 @@ type Config struct {
 func ReadConfig(yamlPath string) (Config, error) {
 	// default values
 	cfg := Config{
-		RootPath:       "./",
+		RootPath:       "./sample",
 		TLSPort:        8443,
 		InsecurePort:   8080,
 		HTTPSRedirect:  true,


### PR DESCRIPTION
This PR fixes issue #6

Changed default RootPath to match what's specified in the readme.

GOBLOG_ROOT can still be used to override default (tested locally).

Added `goblog` binary to .gitignore (should really be outputting to /bin but going with the convention being used).

Ran tests but too many unrelated failures to fix for this simple change.