### PR TITLE
Introduce multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+*.iml
+*.ipr
+*.iws
+*.md
+**/.DS_Store
+.git
+.gitignore
+.idea
+Dockerfile
+README.md
+bin/
+coverage.xml
+etc/
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 coverage.xml
 
 bin/
-
+goblog

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
+# First stage: Compile Go appllication
 FROM golang:1.23 AS builder
 
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 WORKDIR /goblog
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./src ./src
+COPY ./sample ./sample
+RUN go build -o /goblog/goblog ./src
 
-COPY . .
-
-RUN make compile
-
-FROM ubuntu:latest
+# Second stage: Create minimal image with compilled binary
+FROM alpine:latest
 
 WORKDIR /
-
-COPY --from=builder /goblog/bin/goblog /goblog
-
+COPY --from=builder /goblog/goblog /goblog
+COPY --from=builder ./goblog/sample ./sample
 ENTRYPOINT ["/goblog"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ environment variable.
 Environment variables take precedence over YAML configuration.
 
 * env: `GOBLOG_ROOT`, yaml: `rootPath`
-  * The root folder of the blog contens (see [Blog Structure](#blog-structure))
+  * The root folder of the blog contents (see [Blog Structure](#blog-structure))
   * Default: `./sample`
 * env: `GOBLOG_HTTPS_PORT`, yaml: `httpsPort`
   * Port to serve the secure HTTPS content. If set to <0, HTTPS will be disabled.
@@ -77,7 +77,7 @@ The Root contents folders is structured as follows:
 * `entries` subfolder contains MarkDown entries for each entry of the blog.
     * Entries whose file name starts with a timestamp `YYYYMMDDHHMMname.md` will be automatically added to the
       index.
-    
+
     * Entries whose file name starts with other pattern will be treated as pages, and will need to link
       them manually in the template or another entry.
 
@@ -91,7 +91,7 @@ The Root contents folders is structured as follows:
 
 Put static assets in `static/` folder. They will be accessible through the `/static/` URL path.
 
-Put blog entries in `entries/` folder as MarkDown documents. They will be accessible through the 
+Put blog entries in `entries/` folder as MarkDown documents. They will be accessible through the
 `/entry/` URL path (without extension).
 
 Edit blog template files under the `template/` folder.
@@ -104,4 +104,4 @@ will create an entry created at November 28th, 2017 at 13:30.
 The markdown file MUST contain a First-level header (e.g. `# Post title`), that will be used
 as title of the entry in the entry heading and links.
 
-At this early stage of the blog, you *MUST* restart the blog process before changes are visible. 
+At this early stage of the blog, you *MUST* restart the blog process before changes are visible.

--- a/src/install/config.go
+++ b/src/install/config.go
@@ -34,7 +34,7 @@ type Config struct {
 func ReadConfig(yamlPath string) (Config, error) {
 	// default values
 	cfg := Config{
-		RootPath:       "./",
+		RootPath:       "./sample",
 		TLSPort:        8443,
 		InsecurePort:   8080,
 		HTTPSRedirect:  true,


### PR DESCRIPTION
Multi-stage docker build with some enhancements to create a smaller, more secure and efficient build.

- Set envars for optimised build.
- Added .dockerignore so dirs that are not needed and bulk out final image are never copied across (.git, /etc, coverage, etc..)
- use Alpine instead of Ubuntu for smaller image

Ideas for future improvements/implementation
- scratch builds are decent for Go apps
- or post image build - docker slim, grype and syft to secure image and generate SBOM